### PR TITLE
Update tclcloud.tcl

### DIFF
--- a/tclcloud.tcl
+++ b/tclcloud.tcl
@@ -141,7 +141,7 @@ namespace eval tclcloud {
     dict set AWS_address ec2 ap-northeast-1 address ec2.ap-northeast-1.amazonaws.com
     dict set AWS_address ec2 sa-east-1 address ec2.sa-east-1.amazonaws.com
     dict set AWS_product emr version default 2009-03-31
-    dict set AWS_product ec2 version default 2011-01-01
+    dict set AWS_product ec2 version default 2016-11-15
     dict set AWS_product sns version default 2010-03-31
     dict set AWS_product cfn version default 2010-05-15
     dict set AWS_product as version default 2010-08-01


### PR DESCRIPTION
EC2 API version updated, since the API has new parameters:

error: ok HTTP/1.1 400 Bad Request <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>UnknownParameter</Code><Message>The parameter NetworkInterfaceId is not recognized</Message></Error></Errors><RequestID>b9f78342-6ca1-4ea6-9557-7b72b06d3526</RequestID></Response>

Is fixed with this default version change.